### PR TITLE
Better defaults for pricing parameters

### DIFF
--- a/system-parachains/bridge-hubs/bridge-hub-kusama/primitives/src/lib.rs
+++ b/system-parachains/bridge-hubs/bridge-hub-kusama/primitives/src/lib.rs
@@ -162,7 +162,7 @@ pub mod snowbridge {
 	use crate::Balance;
 	use frame_support::parameter_types;
 	use kusama_runtime_constants::currency::UNITS;
-	use snowbridge_core::{gwei, meth, PricingParameters, Rewards};
+	use snowbridge_core::{PricingParameters, Rewards, U256};
 	use sp_runtime::FixedU128;
 
 	parameter_types! {
@@ -172,11 +172,22 @@ pub mod snowbridge {
 		pub const CreateAssetDeposit: u128 = UNITS / 10;
 		/// The pallet index of the Ethereum inbound queue pallet in the Bridge Hub runtime.
 		pub const InboundQueuePalletInstance: u8 = 80;
-		/// Pricing parameters used for fees.
+		/// Default pricing parameters used to calculate bridging fees. Initialized to unit values,
+		/// as it is intended that these parameters should be updated with more
+		/// accurate values prior to bridge activation. This can be performed
+		/// using the `EthereumSystem::set_pricing_parameters` governance extrinsic.
 		pub Parameters: PricingParameters<Balance> = PricingParameters {
-			exchange_rate: FixedU128::from_rational(1, 75),
-			fee_per_gas: gwei(20),
-			rewards: Rewards { local: 1 * UNITS / 100, remote: meth(1) } // 0.01 KSM
+			// ETH/DOT exchange rate
+			exchange_rate: FixedU128::from_rational(1, 1),
+			// Ether fee per gas unit
+			fee_per_gas: U256::one(),
+			// Relayer rewards
+			rewards: Rewards {
+				// Reward for submitting a message to BridgeHub
+				local: 1,
+				// Reward for submitting a message to the Gateway contract on Ethereum
+				remote: U256::one(),
+			}
 		};
 	}
 }

--- a/system-parachains/bridge-hubs/bridge-hub-polkadot/primitives/src/lib.rs
+++ b/system-parachains/bridge-hubs/bridge-hub-polkadot/primitives/src/lib.rs
@@ -153,7 +153,7 @@ pub mod snowbridge {
 	use crate::Balance;
 	use frame_support::parameter_types;
 	use polkadot_runtime_constants::currency::UNITS;
-	use snowbridge_core::{gwei, meth, PricingParameters, Rewards};
+	use snowbridge_core::{PricingParameters, Rewards, U256};
 	use sp_runtime::FixedU128;
 
 	parameter_types! {
@@ -163,11 +163,22 @@ pub mod snowbridge {
 		pub const CreateAssetDeposit: u128 = 10 * UNITS;
 		/// The pallet index of the Ethereum inbound queue pallet in the Bridge Hub runtime.
 		pub const InboundQueuePalletInstance: u8 = 80;
-		/// Pricing parameters used for fees.
+		/// Default pricing parameters used to calculate bridging fees. Initialized to unit values,
+		/// as it is intended that these parameters should be updated with more
+		/// accurate values prior to bridge activation. This can be performed
+		/// using the `EthereumSystem::set_pricing_parameters` governance extrinsic.
 		pub Parameters: PricingParameters<Balance> = PricingParameters {
-			exchange_rate: FixedU128::from_rational(1, 75),
-			fee_per_gas: gwei(20),
-			rewards: Rewards { local: 1 * UNITS / 100, remote: meth(1) } // 0.01 KSM
+			// ETH/DOT exchange rate
+			exchange_rate: FixedU128::from_rational(1, 1),
+			// Ether fee per gas unit
+			fee_per_gas: U256::one(),
+			// Relayer rewards
+			rewards: Rewards {
+				// Reward for submitting a message to BridgeHub
+				local: 1,
+				// Reward for submitting a message to the Gateway contract on Ethereum
+				remote: U256::one(),
+			}
 		};
 	}
 }


### PR DESCRIPTION
As the current values are causing confusion for Parity reviewers